### PR TITLE
Fix update game vote lambda race conditions

### DIFF
--- a/amplify/backend/api/pokergame/schema.graphql
+++ b/amplify/backend/api/pokergame/schema.graphql
@@ -53,11 +53,11 @@ type Game
   type: String
   buyIn: Int
   eventTime: AWSDateTime # selected date and time
-  players: [AWSEmail] # array of players
-  buyInOptions: [BuyInOptions]
-  dateOptions: [DateOptions]
-  timeOptions: [TimeOptions]
-  ipAddresses: [AWSIPAddress]
+  players: [AWSEmail!] # array of players
+  buyInOptions: [BuyInOptions!]
+  dateOptions: [DateOptions!]
+  timeOptions: [TimeOptions!]
+  ipAddresses: [AWSIPAddress!]
 
   status: GameStatus
 

--- a/amplify/backend/api/pokergame/schema.graphql
+++ b/amplify/backend/api/pokergame/schema.graphql
@@ -101,9 +101,9 @@ input GameVote {
   id: ID!
   hostId: ID!
   email: AWSEmail
-  buyInOptions: [BuyInOptionsInput]!
-  dateOptions: [DateOptionsInput]! # array of dates
-  timeOptions: [TimeOptionsInput]! # array of times
+  buyInOptionIdx: Int!
+  dateOptionIdx: Int!
+  timeOptionIdx: Int!
 }
 
 type Mutation {

--- a/amplify/backend/function/updateGameVote/src/index.js
+++ b/amplify/backend/function/updateGameVote/src/index.js
@@ -21,33 +21,31 @@ exports.handler = async (event, context) => {
   console.log("## EVENT: " + rest.serialize(event));
 
   try {
-    let res;
-    if (event.typeName === "Mutation") {
-      res = await updateVotes(event);
+    if (event.typeName !== "Mutation") {
+      throw new Error("Invalid event type");
     }
+    const res = await updateVotes(event);
     return res;
   } catch (error) {
     console.log(error);
-    return error;
+    return rest.formatError(error);
   }
 };
 
 function generateUpdateParams(key, item, email) {
+  const { dateOptionIdx, timeOptionIdx, buyInOptionIdx } = item;
   let updateExpression = "set";
-  let ExpressionAttributeNames = {};
   let ExpressionAttributeValues = {};
 
-  const { dateOptionIdx, timeOptionIdx, buyInOptionIdx } = item;
-  // const dateOptionIdx = 0;
-  // const timeOptionIdx = 0;
-  // const buyInOptionIdx = 0;
   ExpressionAttributeValues[":increment"] = 1;
   updateExpression += ` dateOptions[${dateOptionIdx}].votes = dateOptions[${dateOptionIdx}].votes + :increment ,`;
   updateExpression += ` timeOptions[${timeOptionIdx}].votes = timeOptions[${timeOptionIdx}].votes + :increment , `;
   updateExpression += ` buyInOptions[${buyInOptionIdx}].votes = buyInOptions[${buyInOptionIdx}].votes + :increment `;
 
   // append a player to the list of players
+  let ExpressionAttributeNames = null;
   if (email) {
+    ExpressionAttributeNames = {};
     ExpressionAttributeNames["#players"] = "players";
     ExpressionAttributeValues[":new_email"] = [email];
     ExpressionAttributeValues[":empty_list"] = [];

--- a/amplify/backend/function/updateGameVote/src/index.js
+++ b/amplify/backend/function/updateGameVote/src/index.js
@@ -10,6 +10,12 @@ const rest = require("/opt/nodejs/rest");
 
 const docClient = new AWS.DynamoDB.DocumentClient();
 
+/**
+ * Processes a "vote".
+ * Updates the votes for time, date and buy-in options.
+ * @param {*} event
+ * @param {*} context
+ */
 exports.handler = async (event, context) => {
   console.log("## CONTEXT: " + rest.serialize(context));
   console.log("## EVENT: " + rest.serialize(event));

--- a/amplify/backend/function/updateGameVote/updateGameVote-cloudformation-template.json
+++ b/amplify/backend/function/updateGameVote/updateGameVote-cloudformation-template.json
@@ -110,7 +110,7 @@
         "Timeout": "25",
         "Code": {
           "S3Bucket": "amplify-gameschedulerapi-dev-152734-deployment",
-          "S3Key": "amplify-builds/updateGameVote-6479556c624e66595961-build.zip"
+          "S3Key": "amplify-builds/updateGameVote-6e555143516c706d486e-build.zip"
         }
       }
     },

--- a/amplify/backend/function/updateGameVote/updateGameVote-cloudformation-template.json
+++ b/amplify/backend/function/updateGameVote/updateGameVote-cloudformation-template.json
@@ -110,7 +110,7 @@
         "Timeout": "25",
         "Code": {
           "S3Bucket": "amplify-gameschedulerapi-dev-152734-deployment",
-          "S3Key": "amplify-builds/updateGameVote-6e555143516c706d486e-build.zip"
+          "S3Key": "amplify-builds/updateGameVote-2f464c7444454d736145-build.zip"
         }
       }
     },

--- a/src/API.ts
+++ b/src/API.ts
@@ -3,36 +3,36 @@
 //  This file was automatically generated and should not be edited.
 
 export type GameInput = {
-  id?: string | null,
-  hostId?: string | null,
-  title?: string | null,
-  type?: string | null,
-  buyIn?: number | null,
-  eventTime?: string | null,
-  players?: Array< string | null > | null,
-  buyInOptions?: Array< BuyInOptionsInput | null > | null,
-  dateOptions?: Array< DateOptionsInput | null > | null,
-  timeOptions?: Array< TimeOptionsInput | null > | null,
-  ipAddresses?: Array< string | null > | null,
-  status?: GameStatus | null,
+  id?: string | null;
+  hostId?: string | null;
+  title?: string | null;
+  type?: string | null;
+  buyIn?: number | null;
+  eventTime?: string | null;
+  players?: Array<string | null> | null;
+  buyInOptions?: Array<BuyInOptionsInput | null> | null;
+  dateOptions?: Array<DateOptionsInput | null> | null;
+  timeOptions?: Array<TimeOptionsInput | null> | null;
+  ipAddresses?: Array<string | null> | null;
+  status?: GameStatus | null;
 };
 
 export type BuyInOptionsInput = {
-  amount: number,
-  votes: number,
-  uuid: string,
+  amount: number;
+  votes: number;
+  uuid: string;
 };
 
 export type DateOptionsInput = {
-  date: string,
-  votes: number,
-  uuid: string,
+  date: string;
+  votes: number;
+  uuid: string;
 };
 
 export type TimeOptionsInput = {
-  time: string,
-  votes: number,
-  uuid: string,
+  time: string;
+  votes: number;
+  uuid: string;
 };
 
 export enum GameStatus {
@@ -42,50 +42,49 @@ export enum GameStatus {
   CANCELLED = "CANCELLED",
 }
 
-
 export type GameVote = {
-  id: string,
-  hostId: string,
-  email?: string | null,
-  buyInOptions: Array< BuyInOptionsInput | null >,
-  dateOptions: Array< DateOptionsInput | null >,
-  timeOptions: Array< TimeOptionsInput | null >,
+  id: string;
+  hostId: string;
+  email?: string | null;
+  buyInOptionIdx: number;
+  dateOptionIdx: number;
+  timeOptionIdx: number;
 };
 
 export type CreateUserInput = {
-  id?: string | null,
-  username?: string | null,
-  firstName?: string | null,
-  lastName?: string | null,
-  email?: string | null,
-  image?: string | null,
+  id?: string | null;
+  username?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  email?: string | null;
+  image?: string | null;
 };
 
 export type ModelUserConditionInput = {
-  username?: ModelStringInput | null,
-  firstName?: ModelStringInput | null,
-  lastName?: ModelStringInput | null,
-  email?: ModelStringInput | null,
-  image?: ModelStringInput | null,
-  and?: Array< ModelUserConditionInput | null > | null,
-  or?: Array< ModelUserConditionInput | null > | null,
-  not?: ModelUserConditionInput | null,
+  username?: ModelStringInput | null;
+  firstName?: ModelStringInput | null;
+  lastName?: ModelStringInput | null;
+  email?: ModelStringInput | null;
+  image?: ModelStringInput | null;
+  and?: Array<ModelUserConditionInput | null> | null;
+  or?: Array<ModelUserConditionInput | null> | null;
+  not?: ModelUserConditionInput | null;
 };
 
 export type ModelStringInput = {
-  ne?: string | null,
-  eq?: string | null,
-  le?: string | null,
-  lt?: string | null,
-  ge?: string | null,
-  gt?: string | null,
-  contains?: string | null,
-  notContains?: string | null,
-  between?: Array< string | null > | null,
-  beginsWith?: string | null,
-  attributeExists?: boolean | null,
-  attributeType?: ModelAttributeTypes | null,
-  size?: ModelSizeInput | null,
+  ne?: string | null;
+  eq?: string | null;
+  le?: string | null;
+  lt?: string | null;
+  ge?: string | null;
+  gt?: string | null;
+  contains?: string | null;
+  notContains?: string | null;
+  between?: Array<string | null> | null;
+  beginsWith?: string | null;
+  attributeExists?: boolean | null;
+  attributeType?: ModelAttributeTypes | null;
+  size?: ModelSizeInput | null;
 };
 
 export enum ModelAttributeTypes {
@@ -101,739 +100,786 @@ export enum ModelAttributeTypes {
   _null = "_null",
 }
 
-
 export type ModelSizeInput = {
-  ne?: number | null,
-  eq?: number | null,
-  le?: number | null,
-  lt?: number | null,
-  ge?: number | null,
-  gt?: number | null,
-  between?: Array< number | null > | null,
+  ne?: number | null;
+  eq?: number | null;
+  le?: number | null;
+  lt?: number | null;
+  ge?: number | null;
+  gt?: number | null;
+  between?: Array<number | null> | null;
 };
 
 export type UpdateUserInput = {
-  id: string,
-  username?: string | null,
-  firstName?: string | null,
-  lastName?: string | null,
-  email?: string | null,
-  image?: string | null,
+  id: string;
+  username?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  email?: string | null;
+  image?: string | null;
 };
 
 export type DeleteUserInput = {
-  id?: string | null,
+  id?: string | null;
 };
 
 export type CreateGameInput = {
-  id?: string | null,
-  title: string,
-  type?: string | null,
-  buyIn?: number | null,
-  eventTime?: string | null,
-  players?: Array< string | null > | null,
-  buyInOptions?: Array< BuyInOptionsInput | null > | null,
-  dateOptions?: Array< DateOptionsInput | null > | null,
-  timeOptions?: Array< TimeOptionsInput | null > | null,
-  ipAddresses?: Array< string | null > | null,
-  status?: GameStatus | null,
-  hostId: string,
+  id?: string | null;
+  title: string;
+  type?: string | null;
+  buyIn?: number | null;
+  eventTime?: string | null;
+  players?: Array<string> | null;
+  buyInOptions?: Array<BuyInOptionsInput> | null;
+  dateOptions?: Array<DateOptionsInput> | null;
+  timeOptions?: Array<TimeOptionsInput> | null;
+  ipAddresses?: Array<string> | null;
+  status?: GameStatus | null;
+  hostId: string;
 };
 
 export type ModelGameConditionInput = {
-  title?: ModelStringInput | null,
-  type?: ModelStringInput | null,
-  buyIn?: ModelIntInput | null,
-  eventTime?: ModelStringInput | null,
-  players?: ModelStringInput | null,
-  ipAddresses?: ModelStringInput | null,
-  status?: ModelGameStatusInput | null,
-  hostId?: ModelIDInput | null,
-  and?: Array< ModelGameConditionInput | null > | null,
-  or?: Array< ModelGameConditionInput | null > | null,
-  not?: ModelGameConditionInput | null,
+  title?: ModelStringInput | null;
+  type?: ModelStringInput | null;
+  buyIn?: ModelIntInput | null;
+  eventTime?: ModelStringInput | null;
+  players?: ModelStringInput | null;
+  ipAddresses?: ModelStringInput | null;
+  status?: ModelGameStatusInput | null;
+  hostId?: ModelIDInput | null;
+  and?: Array<ModelGameConditionInput | null> | null;
+  or?: Array<ModelGameConditionInput | null> | null;
+  not?: ModelGameConditionInput | null;
 };
 
 export type ModelIntInput = {
-  ne?: number | null,
-  eq?: number | null,
-  le?: number | null,
-  lt?: number | null,
-  ge?: number | null,
-  gt?: number | null,
-  between?: Array< number | null > | null,
-  attributeExists?: boolean | null,
-  attributeType?: ModelAttributeTypes | null,
+  ne?: number | null;
+  eq?: number | null;
+  le?: number | null;
+  lt?: number | null;
+  ge?: number | null;
+  gt?: number | null;
+  between?: Array<number | null> | null;
+  attributeExists?: boolean | null;
+  attributeType?: ModelAttributeTypes | null;
 };
 
 export type ModelGameStatusInput = {
-  eq?: GameStatus | null,
-  ne?: GameStatus | null,
+  eq?: GameStatus | null;
+  ne?: GameStatus | null;
 };
 
 export type ModelIDInput = {
-  ne?: string | null,
-  eq?: string | null,
-  le?: string | null,
-  lt?: string | null,
-  ge?: string | null,
-  gt?: string | null,
-  contains?: string | null,
-  notContains?: string | null,
-  between?: Array< string | null > | null,
-  beginsWith?: string | null,
-  attributeExists?: boolean | null,
-  attributeType?: ModelAttributeTypes | null,
-  size?: ModelSizeInput | null,
+  ne?: string | null;
+  eq?: string | null;
+  le?: string | null;
+  lt?: string | null;
+  ge?: string | null;
+  gt?: string | null;
+  contains?: string | null;
+  notContains?: string | null;
+  between?: Array<string | null> | null;
+  beginsWith?: string | null;
+  attributeExists?: boolean | null;
+  attributeType?: ModelAttributeTypes | null;
+  size?: ModelSizeInput | null;
 };
 
 export type UpdateGameInput = {
-  id: string,
-  title?: string | null,
-  type?: string | null,
-  buyIn?: number | null,
-  eventTime?: string | null,
-  players?: Array< string | null > | null,
-  buyInOptions?: Array< BuyInOptionsInput | null > | null,
-  dateOptions?: Array< DateOptionsInput | null > | null,
-  timeOptions?: Array< TimeOptionsInput | null > | null,
-  ipAddresses?: Array< string | null > | null,
-  status?: GameStatus | null,
-  hostId?: string | null,
+  id: string;
+  title?: string | null;
+  type?: string | null;
+  buyIn?: number | null;
+  eventTime?: string | null;
+  players?: Array<string> | null;
+  buyInOptions?: Array<BuyInOptionsInput> | null;
+  dateOptions?: Array<DateOptionsInput> | null;
+  timeOptions?: Array<TimeOptionsInput> | null;
+  ipAddresses?: Array<string> | null;
+  status?: GameStatus | null;
+  hostId?: string | null;
 };
 
 export type DeleteGameInput = {
-  id?: string | null,
+  id?: string | null;
 };
 
 export type ModelUserFilterInput = {
-  id?: ModelIDInput | null,
-  username?: ModelStringInput | null,
-  firstName?: ModelStringInput | null,
-  lastName?: ModelStringInput | null,
-  email?: ModelStringInput | null,
-  image?: ModelStringInput | null,
-  and?: Array< ModelUserFilterInput | null > | null,
-  or?: Array< ModelUserFilterInput | null > | null,
-  not?: ModelUserFilterInput | null,
+  id?: ModelIDInput | null;
+  username?: ModelStringInput | null;
+  firstName?: ModelStringInput | null;
+  lastName?: ModelStringInput | null;
+  email?: ModelStringInput | null;
+  image?: ModelStringInput | null;
+  and?: Array<ModelUserFilterInput | null> | null;
+  or?: Array<ModelUserFilterInput | null> | null;
+  not?: ModelUserFilterInput | null;
 };
 
 export type ModelGameFilterInput = {
-  id?: ModelIDInput | null,
-  title?: ModelStringInput | null,
-  type?: ModelStringInput | null,
-  buyIn?: ModelIntInput | null,
-  eventTime?: ModelStringInput | null,
-  players?: ModelStringInput | null,
-  ipAddresses?: ModelStringInput | null,
-  status?: ModelGameStatusInput | null,
-  hostId?: ModelIDInput | null,
-  and?: Array< ModelGameFilterInput | null > | null,
-  or?: Array< ModelGameFilterInput | null > | null,
-  not?: ModelGameFilterInput | null,
+  id?: ModelIDInput | null;
+  title?: ModelStringInput | null;
+  type?: ModelStringInput | null;
+  buyIn?: ModelIntInput | null;
+  eventTime?: ModelStringInput | null;
+  players?: ModelStringInput | null;
+  ipAddresses?: ModelStringInput | null;
+  status?: ModelGameStatusInput | null;
+  hostId?: ModelIDInput | null;
+  and?: Array<ModelGameFilterInput | null> | null;
+  or?: Array<ModelGameFilterInput | null> | null;
+  not?: ModelGameFilterInput | null;
 };
 
 export type UpdateGameStrictMutationVariables = {
-  input?: GameInput | null,
-  nextToken?: string | null,
+  input?: GameInput | null;
+  nextToken?: string | null;
 };
 
 export type UpdateGameStrictMutation = {
-  updateGameStrict:  {
-    __typename: "Game",
-    id: string,
-    title: string,
-    type: string | null,
-    buyIn: number | null,
-    eventTime: string | null,
-    players: Array< string | null > | null,
-    buyInOptions:  Array< {
-      __typename: "BuyInOptions",
-      amount: number,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    dateOptions:  Array< {
-      __typename: "DateOptions",
-      date: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    timeOptions:  Array< {
-      __typename: "TimeOptions",
-      time: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    ipAddresses: Array< string | null > | null,
-    status: GameStatus | null,
-    hostId: string,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-  } | null,
+  updateGameStrict: {
+    __typename: "Game";
+    id: string;
+    title: string;
+    type: string | null;
+    buyIn: number | null;
+    eventTime: string | null;
+    players: Array<string> | null;
+    buyInOptions: Array<{
+      __typename: "BuyInOptions";
+      amount: number;
+      votes: number;
+      uuid: string;
+    }> | null;
+    dateOptions: Array<{
+      __typename: "DateOptions";
+      date: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    timeOptions: Array<{
+      __typename: "TimeOptions";
+      time: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    ipAddresses: Array<string> | null;
+    status: GameStatus | null;
+    hostId: string;
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+  } | null;
 };
 
 export type UpdateGameVoteMutationVariables = {
-  input?: GameVote | null,
+  input?: GameVote | null;
 };
 
 export type UpdateGameVoteMutation = {
-  updateGameVote:  {
-    __typename: "Game",
-    id: string,
-    title: string,
-    type: string | null,
-    buyIn: number | null,
-    eventTime: string | null,
-    players: Array< string | null > | null,
-    buyInOptions:  Array< {
-      __typename: "BuyInOptions",
-      amount: number,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    dateOptions:  Array< {
-      __typename: "DateOptions",
-      date: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    timeOptions:  Array< {
-      __typename: "TimeOptions",
-      time: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    ipAddresses: Array< string | null > | null,
-    status: GameStatus | null,
-    hostId: string,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-  } | null,
+  updateGameVote: {
+    __typename: "Game";
+    id: string;
+    title: string;
+    type: string | null;
+    buyIn: number | null;
+    eventTime: string | null;
+    players: Array<string> | null;
+    buyInOptions: Array<{
+      __typename: "BuyInOptions";
+      amount: number;
+      votes: number;
+      uuid: string;
+    }> | null;
+    dateOptions: Array<{
+      __typename: "DateOptions";
+      date: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    timeOptions: Array<{
+      __typename: "TimeOptions";
+      time: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    ipAddresses: Array<string> | null;
+    status: GameStatus | null;
+    hostId: string;
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+  } | null;
 };
 
 export type CreateUserMutationVariables = {
-  input: CreateUserInput,
-  condition?: ModelUserConditionInput | null,
+  input: CreateUserInput;
+  condition?: ModelUserConditionInput | null;
 };
 
 export type CreateUserMutation = {
-  createUser:  {
-    __typename: "User",
-    id: string,
-    username: string | null,
-    firstName: string | null,
-    lastName: string | null,
-    email: string | null,
-    image: string | null,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-    games:  {
-      __typename: "ModelGameConnection",
-      nextToken: string | null,
-    } | null,
-  } | null,
+  createUser: {
+    __typename: "User";
+    id: string;
+    username: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    email: string | null;
+    image: string | null;
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+    games: {
+      __typename: "ModelGameConnection";
+      nextToken: string | null;
+    } | null;
+  } | null;
 };
 
 export type UpdateUserMutationVariables = {
-  input: UpdateUserInput,
-  condition?: ModelUserConditionInput | null,
+  input: UpdateUserInput;
+  condition?: ModelUserConditionInput | null;
 };
 
 export type UpdateUserMutation = {
-  updateUser:  {
-    __typename: "User",
-    id: string,
-    username: string | null,
-    firstName: string | null,
-    lastName: string | null,
-    email: string | null,
-    image: string | null,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-    games:  {
-      __typename: "ModelGameConnection",
-      nextToken: string | null,
-    } | null,
-  } | null,
+  updateUser: {
+    __typename: "User";
+    id: string;
+    username: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    email: string | null;
+    image: string | null;
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+    games: {
+      __typename: "ModelGameConnection";
+      nextToken: string | null;
+    } | null;
+  } | null;
 };
 
 export type DeleteUserMutationVariables = {
-  input: DeleteUserInput,
-  condition?: ModelUserConditionInput | null,
+  input: DeleteUserInput;
+  condition?: ModelUserConditionInput | null;
 };
 
 export type DeleteUserMutation = {
-  deleteUser:  {
-    __typename: "User",
-    id: string,
-    username: string | null,
-    firstName: string | null,
-    lastName: string | null,
-    email: string | null,
-    image: string | null,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-    games:  {
-      __typename: "ModelGameConnection",
-      nextToken: string | null,
-    } | null,
-  } | null,
+  deleteUser: {
+    __typename: "User";
+    id: string;
+    username: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    email: string | null;
+    image: string | null;
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+    games: {
+      __typename: "ModelGameConnection";
+      nextToken: string | null;
+    } | null;
+  } | null;
 };
 
 export type CreateGameMutationVariables = {
-  input: CreateGameInput,
-  condition?: ModelGameConditionInput | null,
+  input: CreateGameInput;
+  condition?: ModelGameConditionInput | null;
 };
 
 export type CreateGameMutation = {
-  createGame:  {
-    __typename: "Game",
-    id: string,
-    title: string,
-    type: string | null,
-    buyIn: number | null,
-    eventTime: string | null,
-    players: Array< string | null > | null,
-    buyInOptions:  Array< {
-      __typename: "BuyInOptions",
-      amount: number,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    dateOptions:  Array< {
-      __typename: "DateOptions",
-      date: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    timeOptions:  Array< {
-      __typename: "TimeOptions",
-      time: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    ipAddresses: Array< string | null > | null,
-    status: GameStatus | null,
-    hostId: string,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-  } | null,
+  createGame: {
+    __typename: "Game";
+    id: string;
+    title: string;
+    type: string | null;
+    buyIn: number | null;
+    eventTime: string | null;
+    players: Array<string> | null;
+    buyInOptions: Array<{
+      __typename: "BuyInOptions";
+      amount: number;
+      votes: number;
+      uuid: string;
+    }> | null;
+    dateOptions: Array<{
+      __typename: "DateOptions";
+      date: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    timeOptions: Array<{
+      __typename: "TimeOptions";
+      time: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    ipAddresses: Array<string> | null;
+    status: GameStatus | null;
+    hostId: string;
+    host: {
+      __typename: "User";
+      id: string;
+      username: string | null;
+      firstName: string | null;
+      lastName: string | null;
+      email: string | null;
+      image: string | null;
+      createdAt: string;
+      updatedAt: string;
+      owner: string | null;
+    };
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+  } | null;
 };
 
 export type UpdateGameMutationVariables = {
-  input: UpdateGameInput,
-  condition?: ModelGameConditionInput | null,
+  input: UpdateGameInput;
+  condition?: ModelGameConditionInput | null;
 };
 
 export type UpdateGameMutation = {
-  updateGame:  {
-    __typename: "Game",
-    id: string,
-    title: string,
-    type: string | null,
-    buyIn: number | null,
-    eventTime: string | null,
-    players: Array< string | null > | null,
-    buyInOptions:  Array< {
-      __typename: "BuyInOptions",
-      amount: number,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    dateOptions:  Array< {
-      __typename: "DateOptions",
-      date: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    timeOptions:  Array< {
-      __typename: "TimeOptions",
-      time: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    ipAddresses: Array< string | null > | null,
-    status: GameStatus | null,
-    hostId: string,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-  } | null,
+  updateGame: {
+    __typename: "Game";
+    id: string;
+    title: string;
+    type: string | null;
+    buyIn: number | null;
+    eventTime: string | null;
+    players: Array<string> | null;
+    buyInOptions: Array<{
+      __typename: "BuyInOptions";
+      amount: number;
+      votes: number;
+      uuid: string;
+    }> | null;
+    dateOptions: Array<{
+      __typename: "DateOptions";
+      date: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    timeOptions: Array<{
+      __typename: "TimeOptions";
+      time: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    ipAddresses: Array<string> | null;
+    status: GameStatus | null;
+    hostId: string;
+    host: {
+      __typename: "User";
+      id: string;
+      username: string | null;
+      firstName: string | null;
+      lastName: string | null;
+      email: string | null;
+      image: string | null;
+      createdAt: string;
+      updatedAt: string;
+      owner: string | null;
+    };
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+  } | null;
 };
 
 export type DeleteGameMutationVariables = {
-  input: DeleteGameInput,
-  condition?: ModelGameConditionInput | null,
+  input: DeleteGameInput;
+  condition?: ModelGameConditionInput | null;
 };
 
 export type DeleteGameMutation = {
-  deleteGame:  {
-    __typename: "Game",
-    id: string,
-    title: string,
-    type: string | null,
-    buyIn: number | null,
-    eventTime: string | null,
-    players: Array< string | null > | null,
-    buyInOptions:  Array< {
-      __typename: "BuyInOptions",
-      amount: number,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    dateOptions:  Array< {
-      __typename: "DateOptions",
-      date: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    timeOptions:  Array< {
-      __typename: "TimeOptions",
-      time: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    ipAddresses: Array< string | null > | null,
-    status: GameStatus | null,
-    hostId: string,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-  } | null,
+  deleteGame: {
+    __typename: "Game";
+    id: string;
+    title: string;
+    type: string | null;
+    buyIn: number | null;
+    eventTime: string | null;
+    players: Array<string> | null;
+    buyInOptions: Array<{
+      __typename: "BuyInOptions";
+      amount: number;
+      votes: number;
+      uuid: string;
+    }> | null;
+    dateOptions: Array<{
+      __typename: "DateOptions";
+      date: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    timeOptions: Array<{
+      __typename: "TimeOptions";
+      time: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    ipAddresses: Array<string> | null;
+    status: GameStatus | null;
+    hostId: string;
+    host: {
+      __typename: "User";
+      id: string;
+      username: string | null;
+      firstName: string | null;
+      lastName: string | null;
+      email: string | null;
+      image: string | null;
+      createdAt: string;
+      updatedAt: string;
+      owner: string | null;
+    };
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+  } | null;
 };
 
 export type GetUserQueryVariables = {
-  id: string,
+  id: string;
 };
 
 export type GetUserQuery = {
-  getUser:  {
-    __typename: "User",
-    id: string,
-    username: string | null,
-    firstName: string | null,
-    lastName: string | null,
-    email: string | null,
-    image: string | null,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-    games:  {
-      __typename: "ModelGameConnection",
-      nextToken: string | null,
-    } | null,
-  } | null,
+  getUser: {
+    __typename: "User";
+    id: string;
+    username: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    email: string | null;
+    image: string | null;
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+    games: {
+      __typename: "ModelGameConnection";
+      nextToken: string | null;
+    } | null;
+  } | null;
 };
 
 export type ListUsersQueryVariables = {
-  filter?: ModelUserFilterInput | null,
-  limit?: number | null,
-  nextToken?: string | null,
+  filter?: ModelUserFilterInput | null;
+  limit?: number | null;
+  nextToken?: string | null;
 };
 
 export type ListUsersQuery = {
-  listUsers:  {
-    __typename: "ModelUserConnection",
-    items:  Array< {
-      __typename: "User",
-      id: string,
-      username: string | null,
-      firstName: string | null,
-      lastName: string | null,
-      email: string | null,
-      image: string | null,
-      createdAt: string,
-      updatedAt: string,
-      owner: string | null,
-    } | null > | null,
-    nextToken: string | null,
-  } | null,
+  listUsers: {
+    __typename: "ModelUserConnection";
+    items: Array<{
+      __typename: "User";
+      id: string;
+      username: string | null;
+      firstName: string | null;
+      lastName: string | null;
+      email: string | null;
+      image: string | null;
+      createdAt: string;
+      updatedAt: string;
+      owner: string | null;
+    } | null> | null;
+    nextToken: string | null;
+  } | null;
 };
 
 export type GetGameQueryVariables = {
-  id: string,
+  id: string;
 };
 
 export type GetGameQuery = {
-  getGame:  {
-    __typename: "Game",
-    id: string,
-    title: string,
-    type: string | null,
-    buyIn: number | null,
-    eventTime: string | null,
-    players: Array< string | null > | null,
-    buyInOptions:  Array< {
-      __typename: "BuyInOptions",
-      amount: number,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    dateOptions:  Array< {
-      __typename: "DateOptions",
-      date: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    timeOptions:  Array< {
-      __typename: "TimeOptions",
-      time: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    ipAddresses: Array< string | null > | null,
-    status: GameStatus | null,
-    hostId: string,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-  } | null,
+  getGame: {
+    __typename: "Game";
+    id: string;
+    title: string;
+    type: string | null;
+    buyIn: number | null;
+    eventTime: string | null;
+    players: Array<string> | null;
+    buyInOptions: Array<{
+      __typename: "BuyInOptions";
+      amount: number;
+      votes: number;
+      uuid: string;
+    }> | null;
+    dateOptions: Array<{
+      __typename: "DateOptions";
+      date: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    timeOptions: Array<{
+      __typename: "TimeOptions";
+      time: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    ipAddresses: Array<string> | null;
+    status: GameStatus | null;
+    hostId: string;
+    host: {
+      __typename: "User";
+      id: string;
+      username: string | null;
+      firstName: string | null;
+      lastName: string | null;
+      email: string | null;
+      image: string | null;
+      createdAt: string;
+      updatedAt: string;
+      owner: string | null;
+    };
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+  } | null;
 };
 
 export type ListGamesQueryVariables = {
-  filter?: ModelGameFilterInput | null,
-  limit?: number | null,
-  nextToken?: string | null,
+  filter?: ModelGameFilterInput | null;
+  limit?: number | null;
+  nextToken?: string | null;
 };
 
 export type ListGamesQuery = {
-  listGames:  {
-    __typename: "ModelGameConnection",
-    items:  Array< {
-      __typename: "Game",
-      id: string,
-      title: string,
-      type: string | null,
-      buyIn: number | null,
-      eventTime: string | null,
-      players: Array< string | null > | null,
-      ipAddresses: Array< string | null > | null,
-      status: GameStatus | null,
-      hostId: string,
-      createdAt: string,
-      updatedAt: string,
-      owner: string | null,
-    } | null > | null,
-    nextToken: string | null,
-  } | null,
+  listGames: {
+    __typename: "ModelGameConnection";
+    items: Array<{
+      __typename: "Game";
+      id: string;
+      title: string;
+      type: string | null;
+      buyIn: number | null;
+      eventTime: string | null;
+      players: Array<string> | null;
+      ipAddresses: Array<string> | null;
+      status: GameStatus | null;
+      hostId: string;
+      createdAt: string;
+      updatedAt: string;
+      owner: string | null;
+    } | null> | null;
+    nextToken: string | null;
+  } | null;
 };
 
 export type OnCreateUserSubscriptionVariables = {
-  owner?: string | null,
+  owner?: string | null;
 };
 
 export type OnCreateUserSubscription = {
-  onCreateUser:  {
-    __typename: "User",
-    id: string,
-    username: string | null,
-    firstName: string | null,
-    lastName: string | null,
-    email: string | null,
-    image: string | null,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-    games:  {
-      __typename: "ModelGameConnection",
-      nextToken: string | null,
-    } | null,
-  } | null,
+  onCreateUser: {
+    __typename: "User";
+    id: string;
+    username: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    email: string | null;
+    image: string | null;
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+    games: {
+      __typename: "ModelGameConnection";
+      nextToken: string | null;
+    } | null;
+  } | null;
 };
 
 export type OnUpdateUserSubscriptionVariables = {
-  owner?: string | null,
+  owner?: string | null;
 };
 
 export type OnUpdateUserSubscription = {
-  onUpdateUser:  {
-    __typename: "User",
-    id: string,
-    username: string | null,
-    firstName: string | null,
-    lastName: string | null,
-    email: string | null,
-    image: string | null,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-    games:  {
-      __typename: "ModelGameConnection",
-      nextToken: string | null,
-    } | null,
-  } | null,
+  onUpdateUser: {
+    __typename: "User";
+    id: string;
+    username: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    email: string | null;
+    image: string | null;
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+    games: {
+      __typename: "ModelGameConnection";
+      nextToken: string | null;
+    } | null;
+  } | null;
 };
 
 export type OnDeleteUserSubscriptionVariables = {
-  owner?: string | null,
+  owner?: string | null;
 };
 
 export type OnDeleteUserSubscription = {
-  onDeleteUser:  {
-    __typename: "User",
-    id: string,
-    username: string | null,
-    firstName: string | null,
-    lastName: string | null,
-    email: string | null,
-    image: string | null,
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-    games:  {
-      __typename: "ModelGameConnection",
-      nextToken: string | null,
-    } | null,
-  } | null,
+  onDeleteUser: {
+    __typename: "User";
+    id: string;
+    username: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    email: string | null;
+    image: string | null;
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+    games: {
+      __typename: "ModelGameConnection";
+      nextToken: string | null;
+    } | null;
+  } | null;
 };
 
 export type OnCreateGameSubscription = {
-  onCreateGame:  {
-    __typename: "Game",
-    id: string,
-    title: string,
-    type: string | null,
-    buyIn: number | null,
-    eventTime: string | null,
-    players: Array< string | null > | null,
-    buyInOptions:  Array< {
-      __typename: "BuyInOptions",
-      amount: number,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    dateOptions:  Array< {
-      __typename: "DateOptions",
-      date: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    timeOptions:  Array< {
-      __typename: "TimeOptions",
-      time: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    ipAddresses: Array< string | null > | null,
-    status: GameStatus | null,
-    hostId: string,
-    host:  {
-      __typename: "User",
-      id: string,
-      username: string | null,
-      firstName: string | null,
-      lastName: string | null,
-      email: string | null,
-      image: string | null,
-      createdAt: string,
-      updatedAt: string,
-      owner: string | null,
-    },
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-  } | null,
+  onCreateGame: {
+    __typename: "Game";
+    id: string;
+    title: string;
+    type: string | null;
+    buyIn: number | null;
+    eventTime: string | null;
+    players: Array<string> | null;
+    buyInOptions: Array<{
+      __typename: "BuyInOptions";
+      amount: number;
+      votes: number;
+      uuid: string;
+    }> | null;
+    dateOptions: Array<{
+      __typename: "DateOptions";
+      date: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    timeOptions: Array<{
+      __typename: "TimeOptions";
+      time: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    ipAddresses: Array<string> | null;
+    status: GameStatus | null;
+    hostId: string;
+    host: {
+      __typename: "User";
+      id: string;
+      username: string | null;
+      firstName: string | null;
+      lastName: string | null;
+      email: string | null;
+      image: string | null;
+      createdAt: string;
+      updatedAt: string;
+      owner: string | null;
+    };
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+  } | null;
 };
 
 export type OnUpdateGameSubscription = {
-  onUpdateGame:  {
-    __typename: "Game",
-    id: string,
-    title: string,
-    type: string | null,
-    buyIn: number | null,
-    eventTime: string | null,
-    players: Array< string | null > | null,
-    buyInOptions:  Array< {
-      __typename: "BuyInOptions",
-      amount: number,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    dateOptions:  Array< {
-      __typename: "DateOptions",
-      date: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    timeOptions:  Array< {
-      __typename: "TimeOptions",
-      time: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    ipAddresses: Array< string | null > | null,
-    status: GameStatus | null,
-    hostId: string,
-    host:  {
-      __typename: "User",
-      id: string,
-      username: string | null,
-      firstName: string | null,
-      lastName: string | null,
-      email: string | null,
-      image: string | null,
-      createdAt: string,
-      updatedAt: string,
-      owner: string | null,
-    },
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-  } | null,
+  onUpdateGame: {
+    __typename: "Game";
+    id: string;
+    title: string;
+    type: string | null;
+    buyIn: number | null;
+    eventTime: string | null;
+    players: Array<string> | null;
+    buyInOptions: Array<{
+      __typename: "BuyInOptions";
+      amount: number;
+      votes: number;
+      uuid: string;
+    }> | null;
+    dateOptions: Array<{
+      __typename: "DateOptions";
+      date: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    timeOptions: Array<{
+      __typename: "TimeOptions";
+      time: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    ipAddresses: Array<string> | null;
+    status: GameStatus | null;
+    hostId: string;
+    host: {
+      __typename: "User";
+      id: string;
+      username: string | null;
+      firstName: string | null;
+      lastName: string | null;
+      email: string | null;
+      image: string | null;
+      createdAt: string;
+      updatedAt: string;
+      owner: string | null;
+    };
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+  } | null;
 };
 
 export type OnDeleteGameSubscription = {
-  onDeleteGame:  {
-    __typename: "Game",
-    id: string,
-    title: string,
-    type: string | null,
-    buyIn: number | null,
-    eventTime: string | null,
-    players: Array< string | null > | null,
-    buyInOptions:  Array< {
-      __typename: "BuyInOptions",
-      amount: number,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    dateOptions:  Array< {
-      __typename: "DateOptions",
-      date: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    timeOptions:  Array< {
-      __typename: "TimeOptions",
-      time: string,
-      votes: number,
-      uuid: string,
-    } | null > | null,
-    ipAddresses: Array< string | null > | null,
-    status: GameStatus | null,
-    hostId: string,
-    host:  {
-      __typename: "User",
-      id: string,
-      username: string | null,
-      firstName: string | null,
-      lastName: string | null,
-      email: string | null,
-      image: string | null,
-      createdAt: string,
-      updatedAt: string,
-      owner: string | null,
-    },
-    createdAt: string,
-    updatedAt: string,
-    owner: string | null,
-  } | null,
+  onDeleteGame: {
+    __typename: "Game";
+    id: string;
+    title: string;
+    type: string | null;
+    buyIn: number | null;
+    eventTime: string | null;
+    players: Array<string> | null;
+    buyInOptions: Array<{
+      __typename: "BuyInOptions";
+      amount: number;
+      votes: number;
+      uuid: string;
+    }> | null;
+    dateOptions: Array<{
+      __typename: "DateOptions";
+      date: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    timeOptions: Array<{
+      __typename: "TimeOptions";
+      time: string;
+      votes: number;
+      uuid: string;
+    }> | null;
+    ipAddresses: Array<string> | null;
+    status: GameStatus | null;
+    hostId: string;
+    host: {
+      __typename: "User";
+      id: string;
+      username: string | null;
+      firstName: string | null;
+      lastName: string | null;
+      email: string | null;
+      image: string | null;
+      createdAt: string;
+      updatedAt: string;
+      owner: string | null;
+    };
+    createdAt: string;
+    updatedAt: string;
+    owner: string | null;
+  } | null;
 };

--- a/src/API.ts
+++ b/src/API.ts
@@ -419,18 +419,6 @@ export type CreateGameMutation = {
     ipAddresses: Array<string> | null;
     status: GameStatus | null;
     hostId: string;
-    host: {
-      __typename: "User";
-      id: string;
-      username: string | null;
-      firstName: string | null;
-      lastName: string | null;
-      email: string | null;
-      image: string | null;
-      createdAt: string;
-      updatedAt: string;
-      owner: string | null;
-    };
     createdAt: string;
     updatedAt: string;
     owner: string | null;

--- a/src/API.ts
+++ b/src/API.ts
@@ -460,18 +460,6 @@ export type UpdateGameMutation = {
     ipAddresses: Array<string> | null;
     status: GameStatus | null;
     hostId: string;
-    host: {
-      __typename: "User";
-      id: string;
-      username: string | null;
-      firstName: string | null;
-      lastName: string | null;
-      email: string | null;
-      image: string | null;
-      createdAt: string;
-      updatedAt: string;
-      owner: string | null;
-    };
     createdAt: string;
     updatedAt: string;
     owner: string | null;
@@ -513,18 +501,6 @@ export type DeleteGameMutation = {
     ipAddresses: Array<string> | null;
     status: GameStatus | null;
     hostId: string;
-    host: {
-      __typename: "User";
-      id: string;
-      username: string | null;
-      firstName: string | null;
-      lastName: string | null;
-      email: string | null;
-      image: string | null;
-      createdAt: string;
-      updatedAt: string;
-      owner: string | null;
-    };
     createdAt: string;
     updatedAt: string;
     owner: string | null;

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -43,8 +43,8 @@ interface ResultsProps {
 }
 
 interface Coords {
-  x?: string;
-  y?: number;
+  x?: unknown;
+  y?: unknown;
 }
 export default function Results({ game: game_ }: ResultsProps): JSX.Element {
   const game = game_?.getGame;

--- a/src/components/Vote.tsx
+++ b/src/components/Vote.tsx
@@ -182,38 +182,6 @@ const VoteForm = withFormik<VoteFormProps, FormValues>({
     const { game, onSubmit } = props;
     const settings = game.getGame;
     if (settings?.timeOptions && settings?.dateOptions && settings?.buyInOptions) {
-      //   const eventTimes = settings.timeOptions.map((time) => {
-      //     if (time?.time === eventTime) {
-      //       return {
-      //         ...time,
-      //         votes: time.votes + 1,
-      //       };
-      //     } else {
-      //       return time;
-      //     }
-      //   });
-
-      //   const eventDates = settings.dateOptions.map((date) => {
-      //     if (date?.date === eventDate) {
-      //       return {
-      //         ...date,
-      //         votes: date?.votes + 1,
-      //       };
-      //     } else {
-      //       return date;
-      //     }
-      //   });
-
-      //   const buyIns = settings.buyInOptions.map((_buyIn) => {
-      //     if (_buyIn?.amount === parseInt(buyIn)) {
-      //       return {
-      //         ..._buyIn,
-      //         votes: _buyIn?.votes + 1,
-      //       };
-      //     } else {
-      //       return _buyIn;
-      //     }
-      //   });
       try {
         const input = {
           id: settings.id,

--- a/src/components/Vote.tsx
+++ b/src/components/Vote.tsx
@@ -97,8 +97,8 @@ function InnerForm(props: OtherProps & FormikProps<FormValues>) {
                 touched={touched}
                 title="Date *"
                 name="eventDate"
-                options={settings.dateOptions.map((date) => ({
-                  value: date?.date || "",
+                options={settings.dateOptions.map((date, idx) => ({
+                  value: `${idx}`,
                   label: date?.date ? format(new Date(date.date), "EEE MMM dd yyyy") : "",
                 }))}
               />
@@ -114,8 +114,8 @@ function InnerForm(props: OtherProps & FormikProps<FormValues>) {
                 touched={touched}
                 title="Time *"
                 name="eventTime"
-                options={settings?.timeOptions.map((time) => ({
-                  value: time?.time || "",
+                options={settings?.timeOptions.map((time, idx) => ({
+                  value: `${idx}`,
                   label: time?.time ? `${formatTime(time.time)}` : "",
                 }))}
               />
@@ -131,8 +131,8 @@ function InnerForm(props: OtherProps & FormikProps<FormValues>) {
                 touched={touched}
                 title="Buy-in ($) *"
                 name="buyIn"
-                options={settings.buyInOptions.map((buyIn) => ({
-                  value: buyIn?.amount?.toString() || "",
+                options={settings.buyInOptions.map((buyIn, idx) => ({
+                  value: `${idx}`,
                   label: `${buyIn?.amount || ""}`,
                 }))}
               />
@@ -182,47 +182,48 @@ const VoteForm = withFormik<VoteFormProps, FormValues>({
     const { game, onSubmit } = props;
     const settings = game.getGame;
     if (settings?.timeOptions && settings?.dateOptions && settings?.buyInOptions) {
-      const eventTimes = settings.timeOptions.map((time) => {
-        if (time?.time === eventTime) {
-          return {
-            ...time,
-            votes: time.votes + 1,
-          };
-        } else {
-          return time;
-        }
-      });
+      //   const eventTimes = settings.timeOptions.map((time) => {
+      //     if (time?.time === eventTime) {
+      //       return {
+      //         ...time,
+      //         votes: time.votes + 1,
+      //       };
+      //     } else {
+      //       return time;
+      //     }
+      //   });
 
-      const eventDates = settings.dateOptions.map((date) => {
-        if (date?.date === eventDate) {
-          return {
-            ...date,
-            votes: date?.votes + 1,
-          };
-        } else {
-          return date;
-        }
-      });
+      //   const eventDates = settings.dateOptions.map((date) => {
+      //     if (date?.date === eventDate) {
+      //       return {
+      //         ...date,
+      //         votes: date?.votes + 1,
+      //       };
+      //     } else {
+      //       return date;
+      //     }
+      //   });
 
-      const buyIns = settings.buyInOptions.map((_buyIn) => {
-        if (_buyIn?.amount === parseInt(buyIn)) {
-          return {
-            ..._buyIn,
-            votes: _buyIn?.votes + 1,
-          };
-        } else {
-          return _buyIn;
-        }
-      });
+      //   const buyIns = settings.buyInOptions.map((_buyIn) => {
+      //     if (_buyIn?.amount === parseInt(buyIn)) {
+      //       return {
+      //         ..._buyIn,
+      //         votes: _buyIn?.votes + 1,
+      //       };
+      //     } else {
+      //       return _buyIn;
+      //     }
+      //   });
       try {
         const input = {
           id: settings.id,
           hostId: settings.hostId,
-          buyInOptions: buyIns,
-          dateOptions: eventDates,
-          timeOptions: eventTimes,
+          buyInOptionIdx: parseInt(values.buyIn),
+          dateOptionIdx: parseInt(values.eventDate),
+          timeOptionIdx: parseInt(values.eventTime),
           email: email ? email : null,
         };
+        console.log("input", input);
 
         await API.graphql({
           ...graphqlOperation(mutations.updateGameVote, {

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -35,9 +35,44 @@ export const updateGameStrict = /* GraphQL */ `
     }
   }
 `;
-
+export const updateGameVote = /* GraphQL */ `
+  mutation UpdateGameVote($input: GameVote) {
+    updateGameVote(input: $input) {
+      id
+      title
+      type
+      buyIn
+      eventTime
+      players
+      buyInOptions {
+        amount
+        votes
+        uuid
+      }
+      dateOptions {
+        date
+        votes
+        uuid
+      }
+      timeOptions {
+        time
+        votes
+        uuid
+      }
+      ipAddresses
+      status
+      hostId
+      createdAt
+      updatedAt
+      owner
+    }
+  }
+`;
 export const createUser = /* GraphQL */ `
-  mutation CreateUser($input: CreateUserInput!, $condition: ModelUserConditionInput) {
+  mutation CreateUser(
+    $input: CreateUserInput!
+    $condition: ModelUserConditionInput
+  ) {
     createUser(input: $input, condition: $condition) {
       id
       username
@@ -55,7 +90,10 @@ export const createUser = /* GraphQL */ `
   }
 `;
 export const updateUser = /* GraphQL */ `
-  mutation UpdateUser($input: UpdateUserInput!, $condition: ModelUserConditionInput) {
+  mutation UpdateUser(
+    $input: UpdateUserInput!
+    $condition: ModelUserConditionInput
+  ) {
     updateUser(input: $input, condition: $condition) {
       id
       username
@@ -73,7 +111,10 @@ export const updateUser = /* GraphQL */ `
   }
 `;
 export const deleteUser = /* GraphQL */ `
-  mutation DeleteUser($input: DeleteUserInput!, $condition: ModelUserConditionInput) {
+  mutation DeleteUser(
+    $input: DeleteUserInput!
+    $condition: ModelUserConditionInput
+  ) {
     deleteUser(input: $input, condition: $condition) {
       id
       username
@@ -91,7 +132,10 @@ export const deleteUser = /* GraphQL */ `
   }
 `;
 export const createGame = /* GraphQL */ `
-  mutation CreateGame($input: CreateGameInput!, $condition: ModelGameConditionInput) {
+  mutation CreateGame(
+    $input: CreateGameInput!
+    $condition: ModelGameConditionInput
+  ) {
     createGame(input: $input, condition: $condition) {
       id
       title
@@ -123,42 +167,11 @@ export const createGame = /* GraphQL */ `
     }
   }
 `;
-
-export const deleteGame = /* GraphQL */ `
-  mutation DeleteGame($input: DeleteGameInput!, $condition: ModelGameConditionInput) {
-    deleteGame(input: $input, condition: $condition) {
-      id
-      title
-      type
-      buyIn
-      eventTime
-      players
-      buyInOptions {
-        amount
-        votes
-        uuid
-      }
-      dateOptions {
-        date
-        votes
-        uuid
-      }
-      timeOptions {
-        time
-        votes
-        uuid
-      }
-      ipAddresses
-      status
-      hostId
-      createdAt
-      updatedAt
-      owner
-    }
-  }
-`;
 export const updateGame = /* GraphQL */ `
-  mutation UpdateGame($input: UpdateGameInput!, $condition: ModelGameConditionInput) {
+  mutation UpdateGame(
+    $input: UpdateGameInput!
+    $condition: ModelGameConditionInput
+  ) {
     updateGame(input: $input, condition: $condition) {
       id
       title
@@ -190,15 +203,18 @@ export const updateGame = /* GraphQL */ `
     }
   }
 `;
-
-export const updateGameVote = /* GraphQL */ `
-  mutation UpdateGameVote($input: GameVote) {
-    updateGameVote(input: $input) {
+export const deleteGame = /* GraphQL */ `
+  mutation DeleteGame(
+    $input: DeleteGameInput!
+    $condition: ModelGameConditionInput
+  ) {
+    deleteGame(input: $input, condition: $condition) {
       id
       title
       type
       buyIn
       eventTime
+      players
       buyInOptions {
         amount
         votes

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -69,10 +69,7 @@ export const updateGameVote = /* GraphQL */ `
   }
 `;
 export const createUser = /* GraphQL */ `
-  mutation CreateUser(
-    $input: CreateUserInput!
-    $condition: ModelUserConditionInput
-  ) {
+  mutation CreateUser($input: CreateUserInput!, $condition: ModelUserConditionInput) {
     createUser(input: $input, condition: $condition) {
       id
       username
@@ -90,10 +87,7 @@ export const createUser = /* GraphQL */ `
   }
 `;
 export const updateUser = /* GraphQL */ `
-  mutation UpdateUser(
-    $input: UpdateUserInput!
-    $condition: ModelUserConditionInput
-  ) {
+  mutation UpdateUser($input: UpdateUserInput!, $condition: ModelUserConditionInput) {
     updateUser(input: $input, condition: $condition) {
       id
       username
@@ -111,10 +105,7 @@ export const updateUser = /* GraphQL */ `
   }
 `;
 export const deleteUser = /* GraphQL */ `
-  mutation DeleteUser(
-    $input: DeleteUserInput!
-    $condition: ModelUserConditionInput
-  ) {
+  mutation DeleteUser($input: DeleteUserInput!, $condition: ModelUserConditionInput) {
     deleteUser(input: $input, condition: $condition) {
       id
       username
@@ -132,10 +123,7 @@ export const deleteUser = /* GraphQL */ `
   }
 `;
 export const createGame = /* GraphQL */ `
-  mutation CreateGame(
-    $input: CreateGameInput!
-    $condition: ModelGameConditionInput
-  ) {
+  mutation CreateGame($input: CreateGameInput!, $condition: ModelGameConditionInput) {
     createGame(input: $input, condition: $condition) {
       id
       title
@@ -168,10 +156,7 @@ export const createGame = /* GraphQL */ `
   }
 `;
 export const updateGame = /* GraphQL */ `
-  mutation UpdateGame(
-    $input: UpdateGameInput!
-    $condition: ModelGameConditionInput
-  ) {
+  mutation UpdateGame($input: UpdateGameInput!, $condition: ModelGameConditionInput) {
     updateGame(input: $input, condition: $condition) {
       id
       title
@@ -204,10 +189,7 @@ export const updateGame = /* GraphQL */ `
   }
 `;
 export const deleteGame = /* GraphQL */ `
-  mutation DeleteGame(
-    $input: DeleteGameInput!
-    $condition: ModelGameConditionInput
-  ) {
+  mutation DeleteGame($input: DeleteGameInput!, $condition: ModelGameConditionInput) {
     deleteGame(input: $input, condition: $condition) {
       id
       title

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -21,7 +21,11 @@ export const getUser = /* GraphQL */ `
   }
 `;
 export const listUsers = /* GraphQL */ `
-  query ListUsers($filter: ModelUserFilterInput, $limit: Int, $nextToken: String) {
+  query ListUsers(
+    $filter: ModelUserFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
     listUsers(filter: $filter, limit: $limit, nextToken: $nextToken) {
       items {
         id
@@ -46,6 +50,7 @@ export const getGame = /* GraphQL */ `
       type
       buyIn
       eventTime
+      players
       buyInOptions {
         amount
         votes
@@ -71,7 +76,11 @@ export const getGame = /* GraphQL */ `
   }
 `;
 export const listGames = /* GraphQL */ `
-  query ListGames($filter: ModelGameFilterInput, $limit: Int, $nextToken: String) {
+  query ListGames(
+    $filter: ModelGameFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
     listGames(filter: $filter, limit: $limit, nextToken: $nextToken) {
       items {
         id
@@ -79,6 +88,7 @@ export const listGames = /* GraphQL */ `
         type
         buyIn
         eventTime
+        players
         ipAddresses
         status
         hostId

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -21,11 +21,7 @@ export const getUser = /* GraphQL */ `
   }
 `;
 export const listUsers = /* GraphQL */ `
-  query ListUsers(
-    $filter: ModelUserFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
+  query ListUsers($filter: ModelUserFilterInput, $limit: Int, $nextToken: String) {
     listUsers(filter: $filter, limit: $limit, nextToken: $nextToken) {
       items {
         id
@@ -76,11 +72,7 @@ export const getGame = /* GraphQL */ `
   }
 `;
 export const listGames = /* GraphQL */ `
-  query ListGames(
-    $filter: ModelGameFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
+  query ListGames($filter: ModelGameFilterInput, $limit: Int, $nextToken: String) {
     listGames(filter: $filter, limit: $limit, nextToken: $nextToken) {
       items {
         id

--- a/src/graphql/subscriptions.ts
+++ b/src/graphql/subscriptions.ts
@@ -83,6 +83,17 @@ export const onCreateGame = /* GraphQL */ `
       ipAddresses
       status
       hostId
+      host {
+        id
+        username
+        firstName
+        lastName
+        email
+        image
+        createdAt
+        updatedAt
+        owner
+      }
       createdAt
       updatedAt
       owner


### PR DESCRIPTION
Major Changes:
- refactor the UpdateGameVote lambda to increment a specific time, date, and buy in option by 1. Previously we were updating an entire object (e.g. dateOptions) using data in the front-end which could be holding stale values for the votes.